### PR TITLE
[VG-115]: Bump SDK version to 0.1.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raygun.io/sdk",
   "displayName": "RaygunSDK",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
This PR is to bump the SDK version to 0.1.46 in order to align with the NPM package published. The version includes the types which were not previously included.