### PR TITLE
[VG-95]: Add deployment filter type to AlertFilterType enum

### DIFF
--- a/lib/entities/alerts/enums.ts
+++ b/lib/entities/alerts/enums.ts
@@ -39,6 +39,7 @@ export enum AlertFilterType {
   EventUri = "EventUri",
   EventCountry = "EventCountry",
   EventPlatform = "EventPlatform",
+  Deployment = "Deployment",
 }
 
 export enum AlertComparator {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raygun.io/sdk",
   "displayName": "RaygunSDK",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## [VG-95:](https://raygun.atlassian.net/browse/VG-95) Add deployment filter type to AlertFilterType enum

### Description 📝 
This PR is to implement the latest deployment filter type in order to provide clear differences between specified user-inputted deployment version and using monitor latest deployment filter which is correlated with the deployment tracking product

**Updates**
👉 Add Deployment filter type to `AlertFilterType`  enum 

### Test plan 🧪 
- Endpoints are working correctly
- Filter type is passed through successfully

### Author to check 👓 
- [x] Builds pass
- [x] Tested in an alternative environment
- [x] Reviewed by another developer
- [x] Appropriate documentation written

### Reviewer to check ✔️ 
- [ ] Change has been tested on Beta
- [ ] Code is written to standards
- [ ] Appropriate tests have been written

[Engineering docs](https://raygunners.quip.com/ah5PA7OHZaUk)