### PR TITLE
[VG-206]: Update ISlackIntegrationData model to include teamId and botUserId

### DIFF
--- a/lib/entities/integrations/models.ts
+++ b/lib/entities/integrations/models.ts
@@ -8,8 +8,8 @@ export type IWebhooksIntegrationData = {
 
 export type ISlackIntegrationData = {
   accessToken: string | null;
-  teamId: string;
-  botUserId: string;
+  teamId: string | null;
+  botUserId: string |null;
 }
 
 export type IIntegration = {

--- a/lib/entities/integrations/models.ts
+++ b/lib/entities/integrations/models.ts
@@ -8,6 +8,8 @@ export type IWebhooksIntegrationData = {
 
 export type ISlackIntegrationData = {
   accessToken: string | null;
+  teamId: string;
+  botUserId: string;
 }
 
 export type IIntegration = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raygun.io/sdk",
   "displayName": "RaygunSDK",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## [VG-206:](https://raygun.atlassian.net/browse/VG-206) Update ISlackIntegrationData model to include teamId and botUserId

### Description 📝 
This PR is to introduce `teamId` and `botUserId` within the `ISlackIntegrationData`

**Updates**
👉 Add `teamId` and `botUserId` to `ISlackIntegrationData`

### Screenshots 📸 
**Validation**
<img width="477" alt="Screen Shot 2022-07-20 at 4 04 54 PM" src="https://user-images.githubusercontent.com/36393794/179894709-0316414d-c9ef-45af-b68d-6bbad7fc11af.png">

**Successful creation**
<img width="568" alt="Screen Shot 2022-07-20 at 5 07 50 PM" src="https://user-images.githubusercontent.com/36393794/179901435-60848ecb-c149-4a89-8cd9-518e3b895743.png">

### Test plan 🧪 
- New ids appear within `SlackIntegrationData` property
- Validation is working accordingly

### Author to check 👓 
- [ ] Builds pass
- [ ] Tested in an alternative environment
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, Quip docs)

### Reviewer to check ✔️ 
- [ ] Change has been tested on Beta
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, Quip docs)