### PR TITLE
[MST-40]: JS SDK - Extend integration model type to include MS Teams type 👥 

### DIFF
--- a/lib/entities/alerts/enums.ts
+++ b/lib/entities/alerts/enums.ts
@@ -28,7 +28,8 @@ export enum AlertActionType {
 export enum AlertActionSettingType {
   UserId = "UserId",
   IntegrationId = "IntegrationId",
-  SlackChannelId = "SlackChannelId"
+  SlackChannelId = "SlackChannelId",
+  MicrosoftTeamsChannelId = "MicrosoftTeamsChannelId",
 }
 
 export enum AlertTargetType {

--- a/lib/entities/integrations/enums.ts
+++ b/lib/entities/integrations/enums.ts
@@ -2,5 +2,6 @@
 
 export enum IntegrationType {
   Webhook = "Webhook",
-  Slack = "Slack"
+  Slack = "Slack",
+  MsTeams = "MsTeams"
 }

--- a/lib/entities/integrations/enums.ts
+++ b/lib/entities/integrations/enums.ts
@@ -3,5 +3,5 @@
 export enum IntegrationType {
   Webhook = "Webhook",
   Slack = "Slack",
-  MsTeams = "MsTeams"
+  MicrosoftTeams = "MicrosoftTeams"
 }

--- a/lib/entities/integrations/index.ts
+++ b/lib/entities/integrations/index.ts
@@ -72,16 +72,12 @@ export class Integrations {
    * @param identifier - Id related to a specific integration
    * @param userId - Id of the user logged in
    */
-  async delete(planIdentifier: string, identifier: string, userId: string): Promise<void> {
+  async delete(planIdentifier: string, identifier: string): Promise<void> {
     let urlSegments = [planIdentifier, this.baseUrl, identifier];
-
-    const queryParams: IQueryParams = {
-      userId: userId,
-    }
 
     await wrapWithErrorHandler(async () => {
       const url = buildApiUrl(urlSegments);
-      await this.networkClient.deleteFromApi(url, queryParams);
+      await this.networkClient.deleteFromApi(url, undefined);
     });
   }
 }

--- a/lib/entities/integrations/index.ts
+++ b/lib/entities/integrations/index.ts
@@ -70,7 +70,6 @@ export class Integrations {
    * Delete an integration matching the given identifier for the given plan
    * @param planIdentifier - Identifier of the target plan
    * @param identifier - Id related to a specific integration
-   * @param userId - Id of the user logged in
    */
   async delete(planIdentifier: string, identifier: string): Promise<void> {
     let urlSegments = [planIdentifier, this.baseUrl, identifier];

--- a/lib/entities/integrations/index.ts
+++ b/lib/entities/integrations/index.ts
@@ -70,13 +70,18 @@ export class Integrations {
    * Delete an integration matching the given identifier for the given plan
    * @param planIdentifier - Identifier of the target plan
    * @param identifier - Id related to a specific integration
+   * @param userId - Id of the user logged in
    */
-  async delete(planIdentifier: string, identifier: string): Promise<void> {
+  async delete(planIdentifier: string, identifier: string, userId: string): Promise<void> {
     let urlSegments = [planIdentifier, this.baseUrl, identifier];
+
+    const queryParams: IQueryParams = {
+      userId: userId,
+    }
 
     await wrapWithErrorHandler(async () => {
       const url = buildApiUrl(urlSegments);
-      await this.networkClient.deleteFromApi(url, undefined);
+      await this.networkClient.deleteFromApi(url, queryParams);
     });
   }
 }

--- a/lib/entities/integrations/models.ts
+++ b/lib/entities/integrations/models.ts
@@ -13,7 +13,7 @@ export type ISlackIntegrationData = {
 }
 
 export type IMicrosoftTeamsIntegrationData = {
-  teamId: string | null;
+  teamId: string;
   serviceUrl: string | null;
 }
 

--- a/lib/entities/integrations/models.ts
+++ b/lib/entities/integrations/models.ts
@@ -12,11 +12,16 @@ export type ISlackIntegrationData = {
   botUserId: string |null;
 }
 
+export type IMicrosoftTeamsIntegrationData = {
+  teamId: string | null;
+  serviceUrl: string | null;
+}
+
 export type IIntegration = {
     identifier: string;
     name: string;
     type: IntegrationType;
-    data: IWebhooksIntegrationData | ISlackIntegrationData;
+    data: IWebhooksIntegrationData | ISlackIntegrationData | IMicrosoftTeamsIntegrationData;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raygun.io/sdk",
   "displayName": "RaygunSDK",
-  "version": "0.1.61",
+  "version": "0.1.63",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raygun.io/sdk",
   "displayName": "RaygunSDK",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raygun.io/sdk",
   "displayName": "RaygunSDK",
-  "version": "0.1.63",
+  "version": "0.1.62",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## [MST-40:](https://raygun.atlassian.net/browse/MST-40) [JS SDK] Extend integration model type to include MS Teams type 👥

### Description 📝 
This PR is to implement the MS Teams integration type and add an optional userId parameter to the delete integration endpoint

**Updates**
👉 Modify relevant enums to include MS Teams type
👉 Extend `IIntegration` to include the newly made `IMicrosoftTeamsIntegrationData` type
👉 Add new userId parameter to delete integration endpoint
👉 Bump package number

### Screenshots 📷
_Successfully setting up a new MS Teams integration and attempting to create another MS Teams integration on the same plan_
![image](https://user-images.githubusercontent.com/36393794/200691676-61c0c72f-14c7-4d4d-8d9b-07faaa27d5d0.png)

_Bad request (the parameters were out of order)_
![image](https://user-images.githubusercontent.com/36393794/200692014-a9aefa50-348e-456d-a320-98c5de9c2f64.png)

### Test plan 🧪 
- Can pass through an MS Teams type into the integration endpoints
- `userId` parameter on delete integration endpoint is optional

### Author to check 👓 
- [ ] Builds pass
- [ ] Tested in an alternative environment
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, Quip docs)

### Reviewer to check ✔️ 
- [ ] Change has been tested in a separate environment
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, Quip docs)