### PR TITLE
Add new properties to IMicrosoftTeamsIntegrationData

### DIFF
--- a/lib/entities/integrations/models.ts
+++ b/lib/entities/integrations/models.ts
@@ -6,11 +6,13 @@ export type IWebhooksIntegrationData = {
   url: string;
 }
 
-// The reason why some of these properties have the null type
-// is because they are marked as sensitive properties,
-// so they may come back as null from our public api.
-// When adding more properties, check if they are sensitive on the public api
-// If they are, only then give them the null type
+/**
+ * The reason why these properties have a null type
+ * is because they're marked as sensitive properties.
+ * So they may come back as null from our Public API.
+ * When adding more properties, check if they are sensitive on the Public API.
+ * If they are, only then give them the null type.
+ */
 
 export type ISlackIntegrationData = {
   accessToken: string | null;

--- a/lib/entities/integrations/models.ts
+++ b/lib/entities/integrations/models.ts
@@ -6,15 +6,23 @@ export type IWebhooksIntegrationData = {
   url: string;
 }
 
+// The reason why some of these properties have the null type
+// is because they are marked as sensitive properties,
+// so they may come back as null from our public api.
+// When adding more properties, check if they are sensitive on the public api
+// If they are, only then give them the null type
+
 export type ISlackIntegrationData = {
   accessToken: string | null;
   teamId: string | null;
-  botUserId: string |null;
+  botUserId: string | null;
 }
 
 export type IMicrosoftTeamsIntegrationData = {
-  teamId: string;
-  serviceUrl: string | null;
+  teamId: string | null;
+  serviceUrl: string;
+  groupId: string | null;
+  tenantId: string | null;
 }
 
 export type IIntegration = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raygun.io/sdk",
   "displayName": "RaygunSDK",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
# Ticket: [MST-104](https://raygun.atlassian.net/browse/MST-104?atlOrigin=eyJpIjoiZTc4M2JhNjE4NGViNGNkNTkwYTJiNzMyMjk0MjE0MmMiLCJwIjoiaiJ9)

## Description: 
This PR is to introduce new properties on the MicrosoftTeamsIntegrationData model so that we can use the data for Microsft's Graph API 

I've also added a comment to clarify why some properties have the null type 

## Screenshots:
GET integration successful (React test): 
![image](https://user-images.githubusercontent.com/87308551/219507048-26048c0d-13f6-4ed9-842b-e8afd0fa7625.png)

Validation successful
![image](https://user-images.githubusercontent.com/87308551/219518455-8dd25841-8d16-482a-9615-3a6b52c3e730.png)
